### PR TITLE
Add privacy api support

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -20,12 +20,19 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace local_advancedconfig\privacy;
 
-$plugin->component = 'local_advancedconfig';
-$plugin->version = 2018103800;
-$plugin->release = 'v0.3';
-$plugin->requires = 2018050800;
-$plugin->maturity = MATURITY_ALPHA;
-$plugin->cron = 0;
-$plugin->dependencies = array();
+class provider implements
+// This plugin does not store any personal user data.
+\core_privacy\local\metadata\null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+}

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -15,4 +15,6 @@ function xmldb_local_advancedconfig_upgrade($oldversion) {
         // Advancedconfig savepoint reached.
         upgrade_plugin_savepoint(true, 2017101100, 'local', 'advancedconfig');
     }
+
+    return true;
 }

--- a/lang/en/local_advancedconfig.php
+++ b/lang/en/local_advancedconfig.php
@@ -22,3 +22,4 @@ $string['lasthash'] = 'Last update hash';
 $string['cachedef_config'] = 'Config tree cache';
 $string['cachedef_pluginsettings'] = 'Settings definition sources cache';
 $string['cachedef_childclassmap'] = 'Child classes map cache';
+$string['privacy:metadata'] = 'The advanced config plugin extends the settings of other areas of Moodle and does not store user data.';

--- a/version.php
+++ b/version.php
@@ -23,9 +23,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_advancedconfig';
-$plugin->version = 2017112800;
-$plugin->release = 'v0.2';
-$plugin->requires = 2016052300;
-$plugin->maturity = MATURITY_ALPHA;
-$plugin->cron = 0;
-$plugin->dependencies = array();
+$plugin->version = 2018111402;
+$plugin->release = 'v0.31';
+$plugin->requires = 2018050800;
+$plugin->maturity = MATURITY_RC;


### PR DESCRIPTION
This PR adds the Moodle Privacy API (GDPR) support to the plugin.

I've also updated the minimum version of Moodle the plugin will work with, as the privacy implementation uses PHP 7 style type hinting. We can also use the legacy polyfil if required, but it is better to be moving forward.

I added the null provider privacy class to the plugin. This means that the plugin doesn't store user information. This was a tough call. From my understanding of the plugin, even though the plugin is very flexible it won't store user data. As plugin configuration generally doesn't either. The settings defined in this plugin may cause the plugin it is extending to store data, but this is the responsibility of that plugin.

We can always change this approach in the future